### PR TITLE
JBC added mCount to danielT.h and stuff to missileCommand.h

### DIFF
--- a/danielT.h
+++ b/danielT.h
@@ -28,5 +28,6 @@ extern void initRadar(Game *game);
 extern void createSMissile(Game *game);
 extern void sMissilePhysics(Game *game);
 extern void renderSMissile(Game *game);
+extern int mCount;
 
 #endif 

--- a/johnC.cpp
+++ b/johnC.cpp
@@ -63,7 +63,7 @@
 using namespace std;
 extern void dMissileRemove(Game *game, int dMissilenumber);
 extern void createEExplosion(Game *game, float x, float y);
-
+int tempOneTime = 0;
 
 //void changeTitle() 
 //{
@@ -72,6 +72,18 @@ extern void createEExplosion(Game *game, float x, float y);
 
 void renderDefenseMissile(Game *game)
 {
+    extern int mCount;
+    
+    if (game->level * 10 == mCount ) {
+        
+        game->defMissilesRemaining = game->level * 10 *1.5;
+        cout << "defMissiles left in IF: " << game->defMissilesRemaining << endl;
+    }
+    if (game->level * 5 == mCount) {
+        cout << "mCount from JBC: " << mCount << endl;
+    }
+        cout << "defMissiles left: " << game->defMissilesRemaining << endl;
+    
     DefenseMissile *dMissilePtr;
     float w, h;
     
@@ -152,6 +164,7 @@ void dMissileRemove(Game *game, int dMissilenumber)
     game->dMissile[dMissilenumber] = 
         game->dMissile[game->numberDefenseMissiles - 1];
     game->numberDefenseMissiles--;
+    game->defMissilesRemaining--;
 }
 
 void nukeEmAll (Game *game)
@@ -190,9 +203,10 @@ void nukeEmAll (Game *game)
 void makeDefenseMissile(Game *game, int x, int y)
 {
     
-
-    if (game->numberDefenseMissiles >= MAX_D_MISSILES)
+    if (game->numberDefenseMissiles >= MAX_D_MISSILES || 
+            game->defMissilesRemaining <1) {
         return;
+    }
         //std::cout << "makeDefenseMissile()" << x << " " << y << std::endl;
     
         DefenseMissile *dMissilePtr = 

--- a/missileCommand.h
+++ b/missileCommand.h
@@ -221,6 +221,7 @@ struct Game {
     // array of Defense missile explosions
     DExplosion * defExplArray;
     int numDefExplosions;
+    int defMissilesRemaining;
     
     // JBC 05/08/16 JBC switched from DefenseMissile to dMissile (Defense Missile)
     DefenseMissile dMissile[MAX_D_MISSILES];


### PR DESCRIPTION
added extern mCount in danielT.h to allow it to be global across separate source files.
I'm using it as my base for Def missile count. My count is 1.5 x mCount to start.
Also added int defMissilesRemaining to game struct for global access to the number of remaining missiles. we should be able to use that for end level count for bonus.
